### PR TITLE
Add basic poetry support

### DIFF
--- a/pip_check_updates/__init__.py
+++ b/pip_check_updates/__init__.py
@@ -31,7 +31,7 @@ def get_latest_version(name, source, no_ssl_verify):
 
 
 def get_current_version(dep):
-    name, current_version = [token for token in re.split(r"[><=~!]", dep) if token]
+    name, current_version = [token for token in re.split(r"[><=~!^]", dep) if token]
     op = dep[len(name) : -len(current_version)]
     return name, current_version, op
 
@@ -117,7 +117,6 @@ def load_toml(deps, f, p, poetry=False):
     if poetry:
         config = config.get("tool", {}).get("poetry", {})
     separator = "==" if poetry else ""
-
     package_key = "dependencies" if poetry else "packages"
     packages = list(config.get(package_key, {}).items())
     dev_packages = list(config.get(f"dev-{package_key}", {}).items())

--- a/pip_check_updates/__init__.py
+++ b/pip_check_updates/__init__.py
@@ -145,7 +145,9 @@ def load_pyproject(deps, f, p):
 
     results = []
     for key, val in dependencies:
-        if key == 'python':  # poetry allows python interpreter verion alongside deps
+        if key == 'python':
+            # poetry requires a mandatory python version, which is not a valid pip package.
+            # https://python-poetry.org/docs/pyproject/#dependencies-and-dev-dependencies
             continue
 
         if type(val) is str:

--- a/pip_check_updates/__init__.py
+++ b/pip_check_updates/__init__.py
@@ -145,13 +145,17 @@ def load_pyproject(deps, f, p):
 
     results = []
     for key, val in dependencies:
-        if key == 'python':
+        if key == 'python':  # poetry allows python interpreter verion alongside deps
             continue
 
         if type(val) is str:
             if val == "*":
                 continue
             results.append(f"{key}=={val}")
+        elif "version" in val:
+            if val["version"] == "*":
+                continue
+            results.append(f"{key}=={val['version']}")
 
     for dep in results:
         try:

--- a/pip_check_updates/__main__.py
+++ b/pip_check_updates/__main__.py
@@ -37,7 +37,7 @@ def run():
 
     is_txt = req_path.endswith(".txt")
     is_yml = req_path.endswith(".yml") or req_path.endswith(".yaml")
-    is_toml = req_path == "Pipfile"
+    is_toml = req_path == "Pipfile" or req_path.endswith(".toml")
 
     if Path(".pcuignore").exists():
         message = "Please use pcufile.toml instead.\n"

--- a/tests/test_get_current_version.py
+++ b/tests/test_get_current_version.py
@@ -13,6 +13,7 @@ from pip_check_updates import get_current_version
         ("a<1.0", "a", "1.0", "<"),
         ("a~=1.0", "a", "1.0", "~="),
         ("a!=1.0", "a", "1.0", "!="),
+        ("a^1.0", "a", "1.0", "^"),
     ],
 )
 def test_get_current_version(dep, name, version, op):


### PR DESCRIPTION
This builds on the Pipfile checking support and adapts it to support poetry dependencies in `pyproject.toml`.

I manage projects using a mix of different package management tools pip (`requirements.txt`), pipenv and poetry, so having one tool to support them all would be a time saver for me.