### PR TITLE
Support more of the requirements file spec

### DIFF
--- a/pip_check_updates/__init__.py
+++ b/pip_check_updates/__init__.py
@@ -65,8 +65,15 @@ def compare_versions(current_version, latest_version):
 
 
 def load_txt(deps, f, p, recursive):
-    for dep in f.read().splitlines():
+    """
+    https://pip.pypa.io/en/stable/reference/requirements-file-format/
+    https://pip.pypa.io/en/stable/cli/pip_install/#requirement-specifiers
+    """
+    content = f.read()
+    content = re.sub(r"\\\n", "", content)
+    for dep in content.splitlines():
         dep = re.sub(r"#.*", "", dep).strip()
+        dep = re.sub(r";.*", "", dep).strip()
         dep = re.sub(r"{%.*?%}", "", dep).strip()
         dep = re.sub(r"{{.*?}}", "", dep).strip()
         if not dep:

--- a/tests/test_load_txt.py
+++ b/tests/test_load_txt.py
@@ -1,0 +1,41 @@
+import io
+from pathlib import Path
+
+import pytest
+
+from pip_check_updates import load_txt
+
+txt_basic = r"""
+black==22.3.0
+pylint>=2.13.0
+pytest==7.1.*""".strip()
+
+txt_markers_hashes = r"""
+django==3.2.13; python_version >= "3.6" \
+--hash=sha256:b896ca61edc079eb6bbaa15cf6071eb69d6aac08cce5211583cfb41515644fdf \
+--hash=sha256:6d93497a0a9bf6ba0e0b1a29cccdc40efbfc76297255b1309b3a884a688ec4b6
+""".strip()
+
+p = Path("requirements.txt").resolve()
+
+
+@pytest.mark.parametrize(
+    "txt, expected",
+    [
+        (
+            txt_basic,
+            [
+                [p, "black", "22.3.0", "==", "pypi"],
+                [p, "pylint", "2.13.0", ">=", "pypi"],
+                [p, "pytest", "7.1.*", "==", "pypi"],
+            ],
+        ),
+        (txt_markers_hashes, [[p, "django", "3.2.13", "==", "pypi"]]),
+    ],
+)
+def test_load_txt(txt, expected):
+    deps = []
+    with io.StringIO(txt) as f:
+        load_txt(deps, f, p, True)
+
+    assert deps == expected


### PR DESCRIPTION
Support markers and options in the version specifier
Support line continuations using an unescaped \

Add tests for two requirements.txt files

I tried running against a requirements.txt file exported from a poetry project using `poetry export -f requirements.txt --output requirements.txt` and found it used a few things we did not support.

I added a few tests for parsing requirements files, but I'm a bit unsure how to structure it. Did you have ideas on how to structure them and what to test?