### PR TITLE
feat: Support pyproject.toml

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,5 +14,10 @@
   "workbench.colorTheme": "Oceanic Next (dimmed bg)",
   "workbench.editor.enablePreview": false,
   "workbench.iconTheme": "vscode-icons",
-  "workbench.productIconTheme": "material-product-icons"
+  "workbench.productIconTheme": "material-product-icons",
+  "python.testing.pytestArgs": [
+    "tests"
+  ],
+  "python.testing.unittestEnabled": false,
+  "python.testing.pytestEnabled": true
 }

--- a/tests/files/Pipfile
+++ b/tests/files/Pipfile
@@ -1,0 +1,14 @@
+# Pipfile generated via pipenv.
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+requests = "^2.28.0"
+
+[dev-packages]
+black = "^23.0.0"
+
+[requires]
+python_version = "3.10"

--- a/tests/files/poetry.toml
+++ b/tests/files/poetry.toml
@@ -1,0 +1,17 @@
+[tool.poetry]
+name = "poetry_toml_test"
+version = "0.1.0"
+description = "Test file for parsing Poetry TOML files."
+authors = ["Your Name <you@example.com>"]
+readme = "README.md"
+
+[tool.poetry.dependencies]
+python = "^3.10"
+requests = "^2.28.0"
+
+[tool.poetry.group.dev.dependencies]
+black = "^23.0.0"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/tests/files/pyproject.toml
+++ b/tests/files/pyproject.toml
@@ -1,0 +1,18 @@
+[project]
+name = "pyproject_toml_test"
+version = "0.1.0"
+description = "Test file for parsing Setuptools & flit TOML files"
+authors = [{ email = "Your Name <you@example.com>" }]
+readme = "README.md"
+
+dependencies = ["requests~=2.28.0"]
+
+# For setuptools and flit there is no way to mark development dependencies
+# These can be carried via an extra marker, e.g.
+#  pip install package[dev]
+[project.optional-dependencies]
+dev = ["black~=23.0.0"]
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/tests/test_load_toml.py
+++ b/tests/test_load_toml.py
@@ -1,0 +1,65 @@
+import io
+from pathlib import Path
+from typing import List, Tuple
+
+import pytest
+
+from pip_check_updates.parser import load_toml
+
+files_directory = Path(__file__) / ".." / "files"
+test_tomls = [
+    "Pipfile",
+]
+
+
+def toml_path(toml_name: str) -> Path:
+    """Return the correct path object for the TOML file"""
+    return Path(files_directory / toml_name).resolve()
+
+
+expected_packages = [("requests", "2.28.0")]
+expected_dev_packages = [("black", "23.0.0")]
+
+
+def repackage(path: Path, deps: List[Tuple[str, str]]):
+    """Prepare the data as the function returns it."""
+    # Ugly hack but it works.
+
+    if path.name == "pyproject.toml":
+        operator = "=="
+    elif path.name == "poetry.toml":
+        operator = "==^"
+    else:
+        operator = "^"
+    return [
+        [path, dep_name, dep_version, operator, "pypi"]
+        for dep_name, dep_version in deps
+    ]
+
+
+@pytest.mark.parametrize(
+    "file_name, expected",
+    [
+        (
+            "Pipfile",
+            repackage(toml_path("Pipfile"), expected_packages + expected_dev_packages),
+        ),
+        (
+            "poetry.toml",
+            repackage(
+                toml_path("poetry.toml"), expected_packages + expected_dev_packages
+            ),
+        ),
+        (
+            "pyproject.toml",
+            repackage(toml_path("pyproject.toml"), expected_packages),
+        ),
+    ],
+)
+def test_load_dependencies(file_name, expected):
+    deps = []
+    path = toml_path(file_name)
+    with io.open(path, mode="r", encoding="utf8") as f:
+        load_toml(deps, f, path, path.name != "Pipfile")
+
+    assert deps == expected


### PR DESCRIPTION
TOML support was only available for either Pipfile or Poetry project. This commit reworks the *load_toml* method so that it can support also setuptools and flit as build engines.

In addition to that, the function has some tests for it :)