### PR TITLE
feat: Add extras parsing for TOML files

### DIFF
--- a/src/pip_check_updates/__main__.py
+++ b/src/pip_check_updates/__main__.py
@@ -38,6 +38,7 @@ def run():
     show_full_path = get_val("show_full_path")
     no_color = get_val("no_color")
     ignore_additional_labels = get_val("ignore_additional_labels")
+    extra = get_val("extra")
 
     if unknown:
         print(
@@ -65,7 +66,7 @@ def run():
         urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
     try:
-        deps = load_dependencies(req_path, not no_recursive)
+        deps = load_dependencies(req_path, not no_recursive, extra)
     except FileNotFoundError:
         msg = styled_text(
             f"{Path(req_path).absolute()} does not exist.",

--- a/src/pip_check_updates/args.py
+++ b/src/pip_check_updates/args.py
@@ -86,6 +86,13 @@ def get_args():
         default=None,
         help="initialize pcufile.toml.",
     )
+    parser.add_argument(
+        "--extra",
+        action="append",
+        type=str,
+        default=None,
+        help="extras to consider when parsing TOML files. Not used with Pipfile.",
+    )
 
     args, unknown = parser.parse_known_args()
 

--- a/src/pip_check_updates/config.py
+++ b/src/pip_check_updates/config.py
@@ -18,6 +18,7 @@ template = {
     "txt": False,
     "init": False,
     "path": "requirements.txt",
+    "extra": [],
 }
 
 name = "pcufile.toml"

--- a/src/pip_check_updates/version.py
+++ b/src/pip_check_updates/version.py
@@ -28,9 +28,22 @@ def get_latest_version(name, source, no_ssl_verify):
 
 
 def get_current_version(dep):
-    name, current_version = [token for token in re.split(r"[><=~!^]", dep) if token]
+    split_line = [token for token in re.split(r"[><=~!^]", dep) if token]
+
+    # In case of parsing a requirements line like:
+    #  my_depenency
+    # we just want the latest version of the package. Our unpacking later does not like it.
+    # Just add our internal value for matching any version.
+    if len(split_line) < 2:
+        split_line.append("*")
+
+    name, current_version = split_line
     op = dep[len(name) : -len(current_version)]
-    return name, current_version, op
+
+    # Added .strip() for removing whitespace, in case e.g.
+    #  python_dep == 1.2.3
+    # return 'python_dep' and not 'python_dep '
+    return name.strip(), current_version.strip(), op
 
 
 def compare_versions(current_version, latest_version):


### PR DESCRIPTION
- Add a new parameter `extra` which allows to specify packages extra dependencies to check
- Improve requirements line parsing by adding support of
  * bare dependencies e.g. `package`
  * whitespaces within dependencies e.g. `package == 1.2.3`