### PR TITLE
Add --pre flag for managing pre-release package versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,25 @@ Work with Pipenv (WIP)
 pcu Pipfile
 ```
 
+Include unstable versions:
+
+```terminal
+
+pcu --include-unstable
+
+    Checking dependencies
+    100%|████████████████████| 6/6 [00:01<00:00,  5.75it/s]
+
+    In requirements.txt
+
+    Django  3.1.13  →  3.2.6.dev
+    pandas  0.25.3  →  1.3.2.32.dev
+    tqdm    4.62.0  →  4.62.1.2.dev
+
+    Run pcu requirements.txt -u --include-unstable to upgrade versions in 1 file
+
+```
+
 Show the helper text:
 
 ```terminal
@@ -146,7 +165,7 @@ pcu -h
 ```
 
     usage: pcu [-h] [-u] [-f FILTER [FILTER ...]] [-t {latest,newest,greatest,minor,patch}] [-x] [-i] [--no_ssl_verify]
-           [--no_recursive] [--ignore_warning] [--show_full_path] [--no_color] [--ignore_additional_labels] [--init]
+           [--no_recursive] [--ignore_warning] [--show_full_path] [--no_color] [--ignore_additional_labels] [--init] [--pre]
            [path]
 
     pip-check-updates.
@@ -171,6 +190,7 @@ pcu -h
     --ignore_additional_labels
                           ignore additional labels.
     --init                initialize pcufile.toml.
+    --include-unstable   include unstable versions.
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Include unstable versions:
 
 ```terminal
 
-pcu --include-unstable
+pcu --pre
 
     Checking dependencies
     100%|████████████████████| 6/6 [00:01<00:00,  5.75it/s]
@@ -154,7 +154,7 @@ pcu --include-unstable
     pandas  0.25.3  →  1.3.2.32.dev
     tqdm    4.62.0  →  4.62.1.2.dev
 
-    Run pcu requirements.txt -u --include-unstable to upgrade versions in 1 file
+    Run pcu requirements.txt -u to upgrade versions in 1 file
 
 ```
 
@@ -190,7 +190,7 @@ pcu -h
     --ignore_additional_labels
                           ignore additional labels.
     --init                initialize pcufile.toml.
-    --include-unstable   include unstable versions.
+    --pre                 include unstable versions.
 
 ## Credits
 

--- a/src/pip_check_updates/__main__.py
+++ b/src/pip_check_updates/__main__.py
@@ -39,7 +39,7 @@ def run():
     no_color = get_val("no_color")
     ignore_additional_labels = get_val("ignore_additional_labels")
     extra = get_val("extra")
-    include_unstable = get_val("include_unstable")
+    pre = get_val("pre")
 
     if unknown:
         print(
@@ -97,7 +97,7 @@ def run():
         deps, bar_format="{l_bar}{bar:20}{r_bar}", disable=txt_output or not deps
     ):
         latest_version = get_latest_version(
-            name.partition("[")[0], source, no_ssl_verify, include_unstable
+            name.partition("[")[0], source, no_ssl_verify, pre
         )
         if latest_version is None:
             if type(source) is list:

--- a/src/pip_check_updates/__main__.py
+++ b/src/pip_check_updates/__main__.py
@@ -39,6 +39,7 @@ def run():
     no_color = get_val("no_color")
     ignore_additional_labels = get_val("ignore_additional_labels")
     extra = get_val("extra")
+    include_unstable = get_val("include_unstable")
 
     if unknown:
         print(
@@ -96,7 +97,7 @@ def run():
         deps, bar_format="{l_bar}{bar:20}{r_bar}", disable=txt_output or not deps
     ):
         latest_version = get_latest_version(
-            name.partition("[")[0], source, no_ssl_verify
+            name.partition("[")[0], source, no_ssl_verify, include_unstable
         )
         if latest_version is None:
             if type(source) is list:

--- a/src/pip_check_updates/args.py
+++ b/src/pip_check_updates/args.py
@@ -95,7 +95,7 @@ def get_args():
     )
 
     parser.add_argument(
-        "--include_unstable",
+        "--pre",
         action="store_true",
         default=False,
         help="include unstable versions when checking for updates.",

--- a/src/pip_check_updates/args.py
+++ b/src/pip_check_updates/args.py
@@ -94,6 +94,13 @@ def get_args():
         help="extras to consider when parsing TOML files. Not used with Pipfile.",
     )
 
+    parser.add_argument(
+        "--include_unstable",
+        action="store_true",
+        default=False,
+        help="include unstable versions when checking for updates.",
+    )
+
     args, unknown = parser.parse_known_args()
 
     return args, unknown

--- a/src/pip_check_updates/config.py
+++ b/src/pip_check_updates/config.py
@@ -19,7 +19,7 @@ template = {
     "init": False,
     "path": "requirements.txt",
     "extra": [],
-    "include_unstable": False,
+    "pre": False,
 }
 
 name = "pcufile.toml"

--- a/src/pip_check_updates/config.py
+++ b/src/pip_check_updates/config.py
@@ -19,6 +19,7 @@ template = {
     "init": False,
     "path": "requirements.txt",
     "extra": [],
+    "include_unstable": False,
 }
 
 name = "pcufile.toml"

--- a/src/pip_check_updates/version.py
+++ b/src/pip_check_updates/version.py
@@ -5,12 +5,12 @@ from bs4 import BeautifulSoup
 from distutils.version import LooseVersion
 
 
-def get_latest_version(name, source, no_ssl_verify, include_unstable):
+def get_latest_version(name, source, no_ssl_verify, pre):
     if source == "pypi":
         r = requests.get(f"https://pypi.org/pypi/{name}/json", verify=not no_ssl_verify)
         if r.status_code == 200:
             version = r.json()["info"]["version"]
-            if include_unstable:
+            if pre:
                 json_data = r.json()
                 releases = json_data["releases"]
                 for ver in sorted(releases.keys(), key=LooseVersion, reverse=True):

--- a/src/pip_check_updates/version.py
+++ b/src/pip_check_updates/version.py
@@ -2,6 +2,7 @@
 import re
 import requests
 from bs4 import BeautifulSoup
+from distutils.version import LooseVersion
 
 
 def get_latest_version(name, source, no_ssl_verify, include_unstable):
@@ -12,7 +13,7 @@ def get_latest_version(name, source, no_ssl_verify, include_unstable):
             if include_unstable:
                 json_data = r.json()
                 releases = json_data["releases"]
-                for ver in sorted(releases.keys(), reverse=True):
+                for ver in sorted(releases.keys(), key=LooseVersion, reverse=True):
                     release_files = releases[ver]
                     for release_file in release_files:
                         if not release_file["yanked"]:

--- a/tests/test_compare_versions.py
+++ b/tests/test_compare_versions.py
@@ -39,6 +39,17 @@ from pip_check_updates.version import compare_versions
         ("1.*", "1.0.0", None),
         ("1.2.*", "1.3.0", "minor"),
         ("1.*", "2.0.0", "major"),
+        ("1.2.3", "1.2.4-beta", "other"),
+        ("1.2.3-beta", "1.2.3", "patch"),
+        ("1.2.3-beta", "1.2.4-beta", "patch"),
+        ("1.2.3-beta", "1.3.0-alpha", "minor"),
+        ("1.2.3-alpha", "1.2.4-beta", "patch"),
+        ("1.2.3-alpha", "1.3.0-alpha", "minor"),
+        ("1.2.3-alpha", "1.3.0-beta", "minor"),
+        ("1.2.3-alpha", "2.0.0-alpha", "major"),
+        ("1.2.3-alpha", "2.0.0-beta", "major"),
+        ("1.2.3-alpha", "2.0.0-rc", "major"),
+        ("1.2.3-alpha.1", "1.2.3-alpha.2", "other"),
     ],
 )
 def test_compare_versions(current_version, latest_version, change):

--- a/tests/test_get_args.py
+++ b/tests/test_get_args.py
@@ -78,9 +78,9 @@ from pip_check_updates.args import get_args
             ],
         ),
         (
-            ["--include_unstable"],
+            ["--pre"],
             [
-                ("include_unstable", True),
+                ("pre", True),
             ],
         ),
         (

--- a/tests/test_get_args.py
+++ b/tests/test_get_args.py
@@ -78,6 +78,12 @@ from pip_check_updates.args import get_args
             ],
         ),
         (
+            ["--include_unstable"],
+            [
+                ("include_unstable", True),
+            ],
+        ),
+        (
             ["--not_an_valid_argument", "--no_color"],
             [
                 ("not_an_valid_argument", "not valid"),


### PR DESCRIPTION
Hello,

I've recently submitted an issue (#67) regarding the addition of a flag to retrieve the latest version of a package, including unstable versions, specifically for packages hosted on PyPI. After discussing the issue, I have implemented the proposed changes and would like to contribute them to the project.

In this pull request, I have:

1. Added the `--include-unstable` flag to the argument parser, which allows users to opt-in to retrieving the latest available package version, even if it is not stable.
2. Updated the `get_latest_version` function to accept an additional parameter, `include_unstable`, and modified the function's behavior to return the latest available version when this flag is set to `True` and the package source is PyPI.
3. Made necessary changes to the main function to pass the `include_unstable` flag from the command line arguments to the `get_latest_version` function.

To retrieve the latest unstable version, we made the following changes to the original code in the `get_latest_version` function:

1. If the flag is enabled, instead of directly fetching the latest stable version from the `info` field in the JSON response, we now fetch the entire `releases` dictionary.
2. ~~We rely on the assumption that the order of the releases in the JSON response is already chronological, so we can avoid using the `LooseVersion` class for sorting. This decision reduces the complexity of dependencies in our script.~~
3. We iterate through the sorted versions in reverse order (starting from the latest) and check the `yanked` attribute for each release file associated with the version.
4. If the `yanked` attribute is set to `false` for at least one release file, we consider the version as the latest available and return it.

I have tested these changes with various packages on PyPI, and the results are as expected. By default, the script continues to return only the latest stable versions, while using the `--include-unstable` flag allows users to retrieve the latest available version, even if it's not stable.

Please review the changes in this pull request and let me know if you have any suggestions, concerns, or questions. I'm more than happy to make any necessary adjustments or provide additional information.

Thank you for considering my contribution!