### PR TITLE
Add a return code after the checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ pcu -h
                           ignore additional labels.
     --init                initialize pcufile.toml.
     --pre                 include unstable versions.
+    --fail_on_update      exit with code 1 if updates are available.
 
 ## Credits
 

--- a/src/pip_check_updates/__main__.py
+++ b/src/pip_check_updates/__main__.py
@@ -1,3 +1,4 @@
+import sys
 from pathlib import Path
 
 import urllib3
@@ -250,6 +251,11 @@ def run():
                 source = f"channel{s}: {source}"
             message = f"WARNING: could not find {libs} on {source}."
             print(styled_text(message, "warning", no_color))
+
+    if not results:
+        sys.exit(0)
+    else:
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/src/pip_check_updates/__main__.py
+++ b/src/pip_check_updates/__main__.py
@@ -41,6 +41,7 @@ def run():
     ignore_additional_labels = get_val("ignore_additional_labels")
     extra = get_val("extra")
     pre = get_val("pre")
+    fail_on_update = get_val("fail_on_update")
 
     if unknown:
         print(
@@ -252,10 +253,11 @@ def run():
             message = f"WARNING: could not find {libs} on {source}."
             print(styled_text(message, "warning", no_color))
 
-    if not results:
-        sys.exit(0)
-    else:
-        sys.exit(1)
+    if fail_on_update:
+        if not results:
+            sys.exit(0)
+        else:
+            sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/src/pip_check_updates/args.py
+++ b/src/pip_check_updates/args.py
@@ -93,12 +93,16 @@ def get_args():
         default=None,
         help="extras to consider when parsing TOML files. Not used with Pipfile.",
     )
-
     parser.add_argument(
         "--pre",
         action="store_true",
         default=False,
         help="include unstable versions when checking for updates.",
+    )
+    parser.add_argument(
+        "--fail_on_update",
+        action="store_true",
+        help="exit with code 1 if updates are available.",
     )
 
     args, unknown = parser.parse_known_args()

--- a/src/pip_check_updates/config.py
+++ b/src/pip_check_updates/config.py
@@ -20,6 +20,7 @@ template = {
     "path": "requirements.txt",
     "extra": [],
     "pre": False,
+    "fail_on_update": False,
 }
 
 name = "pcufile.toml"


### PR DESCRIPTION
Added a simple return code after all the checks, 0 if there is nothing to update, 1 otherwise.

I didn't put it behind a feature flag because I think the impact is minimal, but I can look into adding it if necessary.