### PR TITLE
ci: bump github actions to latest versions

### DIFF
--- a/.github/workflows/gh-deploy.yml
+++ b/.github/workflows/gh-deploy.yml
@@ -7,9 +7,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
       - run: pip install -r requirements-docs.txt
       - run: mkdocs gh-deploy --force

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -12,9 +12,9 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }} 🐍
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Test with pytest 🧪


### PR DESCRIPTION
This PR upgrades github actions:
- [actions/checkout@v4](https://github.com/actions/checkout?tab=readme-ov-file#usage)
- [actions/setup-python@v5](https://github.com/actions/setup-python?tab=readme-ov-file#basic-usage)

This resolves the following warnings, for example [here](https://github.com/zehengl/pip-check-updates/actions/runs/8602292430):
```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-python@v2. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```