### PR TITLE
Add basic support for PDM

### DIFF
--- a/tests/files/pyproject.pdm.toml
+++ b/tests/files/pyproject.pdm.toml
@@ -1,0 +1,18 @@
+# PDM uses standard pyproject.toml files for project configuration
+# but we're saving it as pyproject.pdm.toml to avoid conflicts with
+# the test pyproject.toml that is used for setuptools and flit
+[project]
+authors = [{email = "Your Name <you@example.com>"}]
+description = "Test file for parsing PDM TOML files"
+name = "pyproject_pdm_toml_test"
+readme = "README.md"
+version = "0.1.0"
+
+dependencies = ["requests~=2.28.0"]
+
+[tool.pdm.dev-dependencies]
+dev = ["black~=23.0.0"]
+
+[build-system]
+build-backend = "pdm-backend"
+requires = ["pdm.backend"]

--- a/tests/test_load_toml.py
+++ b/tests/test_load_toml.py
@@ -27,6 +27,8 @@ def repackage(path: Path, deps: List[Tuple[str, str]]):
 
     if path.name == "pyproject.toml":
         operator = "=="
+    elif path.name == "pyproject.pdm.toml":
+        operator = "=="
     elif path.name == "poetry.toml":
         operator = "==^"
     else:
@@ -53,6 +55,13 @@ def repackage(path: Path, deps: List[Tuple[str, str]]):
         (
             "pyproject.toml",
             repackage(toml_path("pyproject.toml"), expected_packages),
+        ),
+        (
+            "pyproject.pdm.toml",
+            repackage(
+                toml_path("pyproject.pdm.toml"),
+                expected_packages + expected_dev_packages
+            ),
         ),
     ],
 )


### PR DESCRIPTION
In the process I've also refactored the `load_toml` function to separate out the various flavors of TOML config files.

This would close #89.