### PR TITLE
refactor: Parallelize and cache latest-version lookups

### DIFF
--- a/src/pip_check_updates/__main__.py
+++ b/src/pip_check_updates/__main__.py
@@ -1,5 +1,6 @@
 import logging
 import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
 import urllib3
@@ -14,6 +15,16 @@ from .filter import is_a_match
 from .parser import load_dependencies
 from .style import dot_path, styled_text
 from .version import compare_versions, get_latest_version
+
+
+def _normalize_source(source):
+    if isinstance(source, list):
+        return tuple(source)
+    return source
+
+
+def _version_lookup_key(name, source, no_ssl_verify, pre):
+    return (name.partition("[")[0], _normalize_source(source), no_ssl_verify, pre)
 
 
 def run():
@@ -114,12 +125,42 @@ def run():
 
     results = {}
     errors = {}
-    for path, name, current_version, op, source in tqdm(
-        deps, bar_format="{l_bar}{bar:20}{r_bar}", disable=txt_output or not deps
+    filtered_deps = []
+    version_keys = []
+    latest_versions = {}
+
+    for path, name, current_version, op, source in deps:
+        if filter_ and not any([is_a_match(pattern, name) for pattern in filter_]):
+            continue
+        if any([is_a_match(pattern, name) for pattern in ignores]):
+            continue
+
+        key = _version_lookup_key(name, source, no_ssl_verify, pre)
+        filtered_deps.append((path, name, current_version, op, source, key))
+        if key not in latest_versions:
+            version_keys.append(key)
+            latest_versions[key] = None
+
+    if version_keys:
+        with ThreadPoolExecutor() as executor:
+            future_to_key = {
+                executor.submit(get_latest_version, *key): key for key in version_keys
+            }
+            for future in tqdm(
+                as_completed(future_to_key),
+                total=len(future_to_key),
+                bar_format="{l_bar}{bar:20}{r_bar}",
+                disable=txt_output or not filtered_deps,
+            ):
+                key = future_to_key[future]
+                latest_versions[key] = future.result()
+
+    for path, name, current_version, op, source, key in tqdm(
+        filtered_deps,
+        bar_format="{l_bar}{bar:20}{r_bar}",
+        disable=txt_output or not filtered_deps or bool(version_keys),
     ):
-        latest_version = get_latest_version(
-            name.partition("[")[0], source, no_ssl_verify, pre
-        )
+        latest_version = latest_versions[key]
         if latest_version is None:
             if type(source) is list:
                 source = ", ".join(source)
@@ -132,12 +173,10 @@ def run():
         if any(
             [
                 not change,
-                filter_ and not any([is_a_match(pattern, name) for pattern in filter_]),
                 target == "minor" and change == "major",
                 target == "patch"
                 and change in ["latest", "newest", "greatest", "major", "minor"],
                 ignore_additional_labels and change == "other",
-                any([is_a_match(pattern, name) for pattern in ignores]),
             ]
         ):
             continue

--- a/src/pip_check_updates/version.py
+++ b/src/pip_check_updates/version.py
@@ -1,5 +1,6 @@
 """Module responsible for version parsing."""
 
+from functools import lru_cache
 import re
 
 import requests
@@ -7,7 +8,14 @@ from bs4 import BeautifulSoup
 from packaging.version import Version
 
 
-def get_latest_version(name, source, no_ssl_verify, pre):
+def _normalize_source(source):
+    if isinstance(source, list):
+        return tuple(source)
+    return source
+
+
+@lru_cache(maxsize=None)
+def _get_latest_version_cached(name, source, no_ssl_verify, pre):
     if source == "pypi":
         r = requests.get(f"https://pypi.org/pypi/{name}/json", verify=not no_ssl_verify)
         if r.status_code == 200:
@@ -25,7 +33,7 @@ def get_latest_version(name, source, no_ssl_verify, pre):
                         continue
                     break
             return version
-    elif type(source) is list:
+    elif type(source) is tuple:
         version = None
         for channel in source:
             r = requests.get(
@@ -39,6 +47,10 @@ def get_latest_version(name, source, no_ssl_verify, pre):
                     break
         return version
     return None
+
+
+def get_latest_version(name, source, no_ssl_verify, pre):
+    return _get_latest_version_cached(name, _normalize_source(source), no_ssl_verify, pre)
 
 
 def get_current_version(dep):

--- a/tests/test_get_latest_version.py
+++ b/tests/test_get_latest_version.py
@@ -1,0 +1,43 @@
+from types import SimpleNamespace
+
+from pip_check_updates.version import (
+    _get_latest_version_cached,
+    get_latest_version,
+)
+
+
+def test_get_latest_version_caches_pypi_requests(monkeypatch):
+    calls = []
+
+    def fake_get(url, verify=True):
+        calls.append((url, verify))
+        return SimpleNamespace(
+            status_code=200,
+            json=lambda: {"info": {"version": "2.0.0"}, "releases": {}},
+        )
+
+    monkeypatch.setattr("pip_check_updates.version.requests.get", fake_get)
+    _get_latest_version_cached.cache_clear()
+
+    assert get_latest_version("demo-package", "pypi", False, False) == "2.0.0"
+    assert get_latest_version("demo-package", "pypi", False, False) == "2.0.0"
+    assert len(calls) == 1
+
+
+def test_get_latest_version_caches_conda_requests(monkeypatch):
+    calls = []
+
+    def fake_get(url, verify=True):
+        calls.append((url, verify))
+        return SimpleNamespace(
+            status_code=200,
+            content=b'<html><small class="subheader">1.4.0</small></html>',
+        )
+
+    monkeypatch.setattr("pip_check_updates.version.requests.get", fake_get)
+    _get_latest_version_cached.cache_clear()
+
+    source = ["conda-forge", "defaults"]
+    assert get_latest_version("demo-package", source, False, False) == "1.4.0"
+    assert get_latest_version("demo-package", source, False, False) == "1.4.0"
+    assert len(calls) == 1


### PR DESCRIPTION
This change reduces runtime by avoiding duplicate version lookups and fetching unique package metadata concurrently. The main lookup path now caches repeated requests within a run, normalizes source keys so conda channel lists can be reused, and processes unique lookups in parallel before mapping results back to dependencies.